### PR TITLE
chore(ci): Add rust 1.64  to rust min-version variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,14 +86,7 @@ workflows:
               ignore: main
           matrix: &matrix
             parameters:
-              min-rust-version:
-                [
-                  "1.48",
-                  "1.56",
-                  "1.60",
-                  "1.61",
-                  "1.62"
-                ]
+              min-rust-version: ["1.48", "1.56", "1.60", "1.61", "1.62", "1.64"]
 
   test-publish:
     jobs:


### PR DESCRIPTION
- workspace inheritence
[Release Notes](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)