### PR TITLE
fix(Dockerfile): Install clippy and rustfmt components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY --from=binaries $CARGO_HOME/bin/cargo-release $CARGO_HOME/bin/
 COPY --from=binaries $CARGO_HOME/bin/nextsv $CARGO_HOME/bin/
 
 ARG MIN_RUST_VERSION=1.56
+RUN rustup component add clippy rustfmt
 RUN rustup toolchain install stable --component clippy rustfmt
 RUN rustup toolchain install nightly --component clippy rustfmt
 RUN rustup toolchain install beta --component clippy rustfmt


### PR DESCRIPTION
- clippy and rustfmt not installed by default in rust base container.
- install components.
- install/update component for each toolchain installed.