### PR TITLE
ci(ci): Update min-rust-version array in CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ workflows:
               ignore: main
           matrix: &matrix
             parameters:
-              min-rust-version: ["1.61", "1.71", "1.7"]
+              min-rust-version: ["1.61", "1.71", "1.72"]
 
   test-publish:
     jobs:


### PR DESCRIPTION
- add 1.72
- remove redundant versions