### PR TITLE
feat: add new base stage with rust:1.79.0-slim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,23 @@ commands:
             docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}/test:${TAG} --target test .
             docker run --rm ${REPO}/test:${TAG}
 
-  make-publish:
+  publish_rust_env:
+    parameters:
+      rust-min-version:
+        default: "1.56"
+        type: string
+    steps:
+      - run:
+          name: Publish for minimum version <<parameters.rust-min-version>>
+          command: |
+            REPO=jerusdp/ci-rust
+            TAG=<<parameters.rust-min-version>>
+            INPUT_RELEASE_VERSION=0.1.0
+            docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}:${TAG} --target final .
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+            docker push ${REPO}:${TAG}
+
+  publish_base_cmd:
     parameters:
       rust-min-version:
         default: "1.56"
@@ -81,7 +97,7 @@ jobs:
       - make-test:
           rust-min-version: << parameters.min-rust-version >>
 
-  publish:
+  publish_rustcs:
     parameters:
       min-rust-version:
         type: string
@@ -91,8 +107,17 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 20.10.14
-      - make-publish:
+      - publish_rust_env:
           rust-min-version: << parameters.min-rust-version >>
+
+  publish_base:
+    executor: ubuntu
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: 20.10.14
+      - publish_base_cmd
 
   pr-changelog-update:
     executor: ubuntu
@@ -140,9 +165,14 @@ workflows:
             - release
   publish-only:
     jobs:
-      - publish:
+      - publish_rustcs:
           filters:
             branches:
               only: main
           matrix:
             <<: *matrix
+
+      - publish_base:
+          filters:
+            branches:
+              only: main

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "gh/jerus-org/ci-container"
     ],
     "cSpell.words": [
-        "DOCKERHUB"
+        "DOCKERHUB",
+        "rustcs"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - add curl package to the list of installed packages for final container(pr [#64](https://github.com/jerus-org/ci-container/pull/64))
 - add jq package to the list of installed packages in the Dockerfile(pr [#65](https://github.com/jerus-org/ci-container/pull/65))
 - add rust version 1.76(pr [#66](https://github.com/jerus-org/ci-container/pull/66))
+- add new base stage with rust:1.79.0-slim(pr [#68](https://github.com/jerus-org/ci-container/pull/68))
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,16 @@ RUN cargo binstall cargo-release --version 0.25.8 --no-confirm; \
     # cargo binstall pcu --version 0.1.8 --no-confirm;
     cargo install --force --git https://github.com/jerus-org/pcu.git
 
+FROM rust:1.79.0-slim as base
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    jq \
+    ; \
+    rm -rf /var/lib/apt/lists/*;
+
 FROM rust:1.79.0-slim as final
 RUN set -eux; \
     apt-get update; \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ INPUT_RELEASE_VERSION ?= 0.1.0
 MIN_RUST_VERSION ?= 1.56.0
 REPO ?= jerusdp/ci-rust
 TAG ?= $(MIN_RUST_VERSION)
+BASE_TAG ?= base
 
 publish: build
 	$(DOCKER) push $(REPO):${TAG} 
@@ -16,6 +17,9 @@ build:
 
 build-binaries:
 	$(DOCKER) build --no-cache --build-arg MIN_RUST_VERSION=$(MIN_RUST_VERSION) -t $(REPO):${TAG} --target binaries .
+
+build-base:
+	$(DOCKER) build --no-cache  -t $(REPO):${BASE_TAG} --target base .
 
 debug: build
 	$(DOCKER) run --rm -it \


### PR DESCRIPTION
Provide a base container independent of any minimum rust version for use when rust tests of minimum version are not required.

* feat(circleci/config.yml): add publish_rust_env and publish_base_cmd commands
* feat(circleci/config.yml): add publish_rustcs and publish_base jobs
* feat(vscode/settings.json): add "rustcs" to cSpell.words
* feat(Dockerfile): add new base stage with rust:1.79.0-slim
* feat(Makefile): add BASE_TAG variable and build-base target