### PR TITLE
feat(ci): add support for publishing Rust WASI environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     description: "If true, the success pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@1.6.0
+  toolkit: jerus-org/circleci-toolkit@1.6.1
 
 executors:
   ubuntu:
@@ -61,6 +61,22 @@ commands:
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push ${REPO}:${TAG}
 
+  publish_rust_wasi_env:
+    parameters:
+      rust-min-version:
+        default: "1.56"
+        type: string
+    steps:
+      - run:
+          name: Publish for minimum version <<parameters.rust-min-version>>
+          command: |
+            REPO=jerusdp/ci-rust
+            TAG=<<parameters.rust-min-version>>-wasi
+            INPUT_RELEASE_VERSION=0.1.0
+            docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}:${TAG} --target wasi .
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+            docker push ${REPO}:${TAG}
+
   publish_base_cmd:
     steps:
       - run:
@@ -95,6 +111,18 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - publish_rust_env:
+          rust-min-version: << parameters.min-rust-version >>
+
+  publish_rustc_wasi_version:
+    parameters:
+      min-rust-version:
+        type: string
+    executor: ubuntu
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - publish_rust_wasi_env:
           rust-min-version: << parameters.min-rust-version >>
 
   publish_base:
@@ -188,7 +216,6 @@ workflows:
           min_rust_version: << pipeline.parameters.min-rust-version >>
           context:
             - bot-check
-            - release
 
   release:
     when:
@@ -211,5 +238,7 @@ workflows:
       - publish_rustc_version:
           matrix:
             <<: *matrix
-
+      - publish_rustc_wasi_version:
+          matrix:
+            <<: *matrix
       - publish_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ workflows:
           filters:
             branches:
               only: main
-          ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           context:
             - bot-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- add support for publishing Rust WASI environment(pr [#116])
+
 ### Changed
 
 - ci-add label_option to CircleCI config and rangeStrategy to Renovate config(pr [#112])
@@ -184,6 +188,7 @@ All notable changes to this project will be documented in this file.
 [#113]: https://github.com/jerus-org/ci-container/pull/113
 [#114]: https://github.com/jerus-org/ci-container/pull/114
 [#115]: https://github.com/jerus-org/ci-container/pull/115
+[#116]: https://github.com/jerus-org/ci-container/pull/116
 [Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.6...HEAD
 [0.1.6]: https://github.com/jerus-org/ci-container/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/jerus-org/ci-container/compare/v0.1.4...v0.1.5

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 DOCKER ?= docker
 INPUT_RELEASE_VERSION ?= 0.1.0
-MIN_RUST_VERSION ?= 1.56.0
+MIN_RUST_VERSION ?= 1.65.0
 REPO ?= jerusdp/ci-rust
 TAG ?= $(MIN_RUST_VERSION)
 BASE_TAG ?= base
+WASI_TAG ?= wasi
 
 publish: build
 	$(DOCKER) push $(REPO):${TAG} 
@@ -19,12 +20,20 @@ build-binaries:
 	$(DOCKER) build --no-cache --build-arg MIN_RUST_VERSION=$(MIN_RUST_VERSION) -t $(REPO):${TAG} --target binaries .
 
 build-base:
-	$(DOCKER) build --no-cache  -t $(REPO):${BASE_TAG} --target base .
+	$(DOCKER) build --no-cache -t $(REPO):${BASE_TAG} --target base .
+
+build-wasi:
+	$(DOCKER) build --no-cache --build-arg MIN_RUST_VERSION=$(MIN_RUST_VERSION) -t $(REPO):${TAG}-${WASI_TAG} --target wasi .
 
 debug: build
 	$(DOCKER) run --rm -it \
 		--entrypoint=/bin/bash \
-		$(REPO):$(TAG)
+		$(REPO):${TAG}
+
+debug-wasi: build-wasi
+	$(DOCKER) run --rm -it \
+		--entrypoint=/bin/bash \
+		$(REPO):${TAG}-${WASI_TAG} 
 
 debug-binaries : build-binaries
 	$(DOCKER) run --rm -it \


### PR DESCRIPTION
- update CircleCI config to include publish_rust_wasi_env command
- add publish_rustc_wasi_version job to CircleCI config
- update Dockerfile to install wasmtime-cli and create WASI stage
- modify Makefile to include build and debug targets for WASI environment