### PR TITLE
ci(circleci): update toolkit version and improve pipeline workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     description: "If true, the success pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.0.0
+  toolkit: jerus-org/circleci-toolkit@2.0.4
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
@@ -276,11 +276,34 @@ workflows:
         - not: << pipeline.parameters.success-flag >>
         - not: << pipeline.parameters.validation-flag >>
     jobs:
-      - toolkit/make_release:
+      - publish_rustc_version:
+          matrix:
+            <<: *matrix
+      - publish_rustc_wasi_version:
+          matrix:
+            <<: *matrix
+      - publish_base
+
+      - toolkit/save_next_version:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
           requires:
             - publish_rustc_version
             - publish_rustc_wasi_version
             - publish_base
+
+      - toolkit/make_release:
+          requires:
+            - toolkit/save_next_version
+          pre-steps:
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                name: Set SEMVER based on next-version file
+                command: |
+                  set +ex
+                  export SEMVER=$(cat /tmp/workspace/next-version)
+                  echo $SEMVER
+                  echo "export SEMVER=$SEMVER" >> "$BASH_ENV"
           context:
             - release
             - bot-check
@@ -289,10 +312,9 @@ workflows:
           when_cargo_release: false
           when_use_workspace: false
           pcu_update_changelog: true
-      - publish_rustc_version:
-          matrix:
-            <<: *matrix
-      - publish_rustc_wasi_version:
-          matrix:
-            <<: *matrix
-      - publish_base
+
+      - toolkit/no_release:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          requires:
+            - toolkit/save_next_version:
+                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - ci-update CircleCI config to include when_use_workspace parameter and remove pcu_verbosity(pr [#212])
+- ci(circleci)-update toolkit version and improve pipeline workflow(pr [#217])
 
 ### Security
 
@@ -529,6 +530,7 @@ All notable changes to this project will be documented in this file.
 [#213]: https://github.com/jerus-org/ci-container/pull/213
 [#214]: https://github.com/jerus-org/ci-container/pull/214
 [#215]: https://github.com/jerus-org/ci-container/pull/215
+[#217]: https://github.com/jerus-org/ci-container/pull/217
 [Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.29...HEAD
 [0.1.29]: https://github.com/jerus-org/ci-container/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/jerus-org/ci-container/compare/v0.1.27...v0.1.28


### PR DESCRIPTION
- update circleci-toolkit orb to version 2.0.4
- restructure jobs to include save_next_version with release requirements
- add pre-steps for make_release, implementing SEMVER setting
- include a no_release step dependent on save_next_version failure