### PR TITLE
👷 ci(circleci): update Rust version matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,22 +220,7 @@ workflows:
               ignore: main
           matrix: &matrix
             parameters:
-              min-rust-version:
-                [
-                  "1.61",
-                  "1.65",
-                  "1.67",
-                  "1.70",
-                  "1.71",
-                  "1.72",
-                  "1.73",
-                  "1.74",
-                  "1.75",
-                  "1.76",
-                  "1.78",
-                  "1.79",
-                  "1.81",
-                ]
+              min-rust-version: ["1.75", "1.76", "1.78", "1.79", "1.81", "1.85"]
       - security:
           cargo_audit: false
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,19 @@ commands:
       - run:
           name: make test for minimum version <<parameters.rust-min-version>>
           command: |
+            if [[ "1.85" == *"<<parameters.rust-min-version>>"* ]]; then
+              wasi_name="wasm32-wasip1"
+            else
+              wasi_name="wasm32-wasi"
+            fi
+
             REPO=jerusdp/ci-rust
             TAG=<<parameters.rust-min-version>>
-            docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}/test:${TAG}-wasi --target test .
+            docker build \
+                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> \
+                --build-arg MIN_RUST_WASI=$wasi_name \
+                -t ${REPO}/test:${TAG}-wasi \
+                --target test .
             docker run --rm ${REPO}/test:${TAG}-wasi
 
   publish_rust_env:
@@ -62,10 +72,20 @@ commands:
       - run:
           name: Publish for minimum version <<parameters.rust-min-version>>
           command: |
+            if [[ "1.85" == *"<<parameters.rust-min-version>>"* ]]; then
+              wasi_name="wasm32-wasip1"
+            else
+              wasi_name="wasm32-wasi"
+            fi
+
             REPO=jerusdp/ci-rust
             TAG=<<parameters.rust-min-version>>
             INPUT_RELEASE_VERSION=0.1.0
-            docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}:${TAG} --target final .
+            docker build \
+                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> \
+                --build-arg MIN_RUST_WASI=$wasi_name \
+                -t ${REPO}:${TAG} \
+                --target final .
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push ${REPO}:${TAG}
 
@@ -78,10 +98,20 @@ commands:
       - run:
           name: Publish for minimum version <<parameters.rust-min-version>>
           command: |
+            if [[ "1.85" == *"<<parameters.rust-min-version>>"* ]]; then
+              wasi_name="wasm32-wasip1"
+            else
+              wasi_name="wasm32-wasi"
+            fi
+
             REPO=jerusdp/ci-rust
             TAG=<<parameters.rust-min-version>>
             INPUT_RELEASE_VERSION=0.1.0
-            docker build --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> -t ${REPO}:${TAG}-wasi --target wasi .
+            docker build \
+                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>>\
+                --build-arg MIN_RUST_WASI=$wasi_name \
+                -t ${REPO}:${TAG}-wasi \
+                --target wasi .
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push ${REPO}:${TAG}-wasi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- 👷 ci(circleci)-update Rust version matrix(pr [#246])
+
 ### Security
 
 - Dependencies: update dependency cargo-audit to v0.21.2(pr [#240])
@@ -623,6 +627,7 @@ All notable changes to this project will be documented in this file.
 [#243]: https://github.com/jerus-org/ci-container/pull/243
 [#244]: https://github.com/jerus-org/ci-container/pull/244
 [#245]: https://github.com/jerus-org/ci-container/pull/245
+[#246]: https://github.com/jerus-org/ci-container/pull/246
 [Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.35...HEAD
 [0.1.35]: https://github.com/jerus-org/ci-container/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/jerus-org/ci-container/compare/v0.1.33...v0.1.34

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,10 @@ COPY --from=binaries $CARGO_HOME/bin/cargo-release \
     $CARGO_HOME/bin/circleci-junit-fix $CARGO_HOME/bin/
 ARG MIN_RUST_VERSION=1.65
 RUN rustup component add clippy rustfmt llvm-tools; \
-    rustup toolchain install stable --component clippy rustfmt; \
-    rustup toolchain install nightly --component clippy rustfmt; \
-    rustup toolchain install beta --component clippy rustfmt; \
-    rustup toolchain install $MIN_RUST_VERSION --component clippy rustfmt;  
+    rustup toolchain install stable --component clippy --component rustfmt; \
+    rustup toolchain install nightly --component clippy --component rustfmt; \
+    rustup toolchain install beta --component clippy --component rustfmt; \
+    rustup toolchain install $MIN_RUST_VERSION --component clippy --component rustfmt;  
 USER circleci
 WORKDIR /home/circleci/project
 


### PR DESCRIPTION
- remove older Rust versions from matrix to streamline builds
- add Rust version 1.85 to ensure compatibility with latest updates