### PR TITLE
👷 ci(circleci): update toolkit version and simplify workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     description: "If true, the release pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.9.1
+  toolkit: jerus-org/circleci-toolkit@2.10.3
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
@@ -310,26 +310,7 @@ workflows:
             <<: *matrix
       - publish_base
 
-      - toolkit/save_next_version:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-          requires:
-            - publish_rustc_version
-            - publish_rustc_wasi_version
-            - publish_base
-
       - toolkit/make_release:
-          requires:
-            - toolkit/save_next_version
-          pre-steps:
-            - attach_workspace:
-                at: /tmp/workspace
-            - run:
-                name: Set SEMVER based on next-version file
-                command: |
-                  set +ex
-                  export SEMVER=$(cat /tmp/workspace/next-version)
-                  echo $SEMVER
-                  echo "export SEMVER=$SEMVER" >> "$BASH_ENV"
           context:
             - release
             - bot-check
@@ -338,9 +319,3 @@ workflows:
           when_cargo_release: false
           when_use_workspace: false
           pcu_update_changelog: true
-
-      - toolkit/no_release:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-          requires:
-            - toolkit/save_next_version:
-                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-update toolkit version and simplify workflows(pr [#271])
+
 ## [0.1.44] - 2025-04-27
 
 ### Changed
@@ -717,6 +723,8 @@ All notable changes to this project will be documented in this file.
 [#267]: https://github.com/jerus-org/ci-container/pull/267
 [#268]: https://github.com/jerus-org/ci-container/pull/268
 [#269]: https://github.com/jerus-org/ci-container/pull/269
+[#271]: https://github.com/jerus-org/ci-container/pull/271
+[Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.44...HEAD
 [0.1.44]: https://github.com/jerus-org/ci-container/compare/v0.1.43...v0.1.44
 [0.1.43]: https://github.com/jerus-org/ci-container/compare/v0.1.42...v0.1.43
 [0.1.42]: https://github.com/jerus-org/ci-container/compare/v0.1.41...v0.1.42


### PR DESCRIPTION
- update circleci-toolkit orb from version 2.9.1 to 2.10.3
- remove unnecessary steps from the release workflow for efficiency