### PR TITLE
👷 ci(circleci): update toolkit orb and adjust workflow dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     description: "If true, the release pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.3
+  toolkit: jerus-org/circleci-toolkit@2.10.4
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
@@ -305,10 +305,16 @@ workflows:
       - publish_rustc_version:
           matrix:
             <<: *matrix
+          requires:
+            - publish_base
       - publish_rustc_wasi_version:
           matrix:
             <<: *matrix
-      - publish_base
+          requires:
+            - publish_rustc_version
+      - publish_base:
+          requires:
+            - toolkit/make_release
 
       - toolkit/make_release:
           context:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-update toolkit orb and adjust workflow dependencies(pr [#272])
+
 ## [0.1.45] - 2025-04-29
 
 ### Changed
@@ -724,6 +730,8 @@ All notable changes to this project will be documented in this file.
 [#268]: https://github.com/jerus-org/ci-container/pull/268
 [#269]: https://github.com/jerus-org/ci-container/pull/269
 [#271]: https://github.com/jerus-org/ci-container/pull/271
+[#272]: https://github.com/jerus-org/ci-container/pull/272
+[Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.45...HEAD
 [0.1.45]: https://github.com/jerus-org/ci-container/compare/v0.1.44...v0.1.45
 [0.1.44]: https://github.com/jerus-org/ci-container/compare/v0.1.43...v0.1.44
 [0.1.43]: https://github.com/jerus-org/ci-container/compare/v0.1.42...v0.1.43


### PR DESCRIPTION
- upgrade toolkit orb version from 2.10.3 to 2.10.4 for latest features
- add requires dependencies to ensure correct workflow execution order