### PR TITLE
👷 ci(circleci): remove unnecessary pcu update flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,6 @@ workflows:
           when_cargo_release: false
           when_use_workspace: false
           pcu_update_changelog: true
-          when_update_pcu: true
 
   deploy:
     when:


### PR DESCRIPTION
- delete the when_update_pcu flag from circleci config
- streamline the deployment workflow configuration