### PR TITLE
🔧 chore(config): update source URL for CircleCI toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - 👷 ci(circleci)-remove unnecessary pcu update flag(pr [#300])
 - 💄 style(Dockerfile)-remove redundant curl flag(pr [#301])
+- 🔧 chore(config)-update source URL for CircleCI toolkit(pr [#303])
 
 ## [0.1.52] - 2025-07-08
 
@@ -828,6 +829,7 @@ All notable changes to this project will be documented in this file.
 [#299]: https://github.com/jerus-org/ci-container/pull/299
 [#300]: https://github.com/jerus-org/ci-container/pull/300
 [#301]: https://github.com/jerus-org/ci-container/pull/301
+[#303]: https://github.com/jerus-org/ci-container/pull/303
 [Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.52...HEAD
 [0.1.52]: https://github.com/jerus-org/ci-container/compare/v0.1.51...v0.1.52
 [0.1.51]: https://github.com/jerus-org/ci-container/compare/v0.1.50...v0.1.51

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
   ],
   "packageRules": [
     {
-      "sourceUrl": "https://github.com/jerus-org/circleci-toolkit",
+      "sourceUrl": "https://circleci.com/developer/orbs/orb/jerus-org/circleci-toolkit",
       "enabled": true,
       "matchPackageNames": [
         "/jerus-org/circleci-toolkit/"


### PR DESCRIPTION
- change sourceUrl to point to the CircleCI developer orbs page
- ensure accurate URL for package management