### PR TITLE
👷 ci(circleci): fix parameter references in config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,12 +177,12 @@ commands:
           command: |
             set -exo pipefail
 
-            if [ "" != "<< path_to_crate >>" ]; then
+            if [ "" != "<< parameters.path_to_crate >>" ]; then
               cargo install --force --path << parameters.path_to_crate >>
             fi
 
-            if [ "" != "<< crate >>"]; then
-              cargo install --force << crate >>
+            if [ "" != "<< parameters.crate >>"]; then
+              cargo install --force << parameters.crate >>
             fi 
 
             cargo install --list


### PR DESCRIPTION
- correct parameter syntax for path_to_crate and crate
- ensure proper installation of crates with updated syntax