### PR TITLE
🐛 fix(ci): add missing semicolon in conditional statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ commands:
           command: |
             set -exo pipefail
 
-            if [ "$SEMVER" == "" ]
+            if [ "$SEMVER" == "" ]; then
               gen-changelog << parameters.verbosity >> generate --display-summaries 
             else 
               gen-changelog << parameters.verbosity >> generate --display-summaries -next-version $SEMVER

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 - 👷 ci(circleci)-fix parameter references in config(pr [#311])
 - 👷 ci(circleci)-fix syntax error in config.yml(pr [#312])
 
+### Fixed
+
+- 🐛 ci: add missing semicolon in conditional statement(pr [#313])
+
 ## [0.1.54] - 2025-08-03
 
 ### Changed
@@ -863,6 +867,7 @@ All notable changes to this project will be documented in this file.
 [#310]: https://github.com/jerus-org/ci-container/pull/310
 [#311]: https://github.com/jerus-org/ci-container/pull/311
 [#312]: https://github.com/jerus-org/ci-container/pull/312
+[#313]: https://github.com/jerus-org/ci-container/pull/313
 [Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.54...HEAD
 [0.1.54]: https://github.com/jerus-org/ci-container/compare/v0.1.53...v0.1.54
 [0.1.53]: https://github.com/jerus-org/ci-container/compare/v0.1.52...v0.1.53


### PR DESCRIPTION
- include missing semicolon in if condition to ensure proper syntax and execution