### PR TITLE
👷 ci(config): update rust versions in CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,7 +615,17 @@ workflows:
           matrix: &matrix
             parameters:
               min-rust-version:
-                ["1.75", "1.76", "1.78", "1.79", "1.81", "1.82", "1.85", "1.87"]
+                [
+                  "1.75",
+                  "1.76",
+                  "1.78",
+                  "1.79",
+                  "1.81",
+                  "1.82",
+                  "1.85",
+                  "1.87",
+                  "1.88",
+                ]
       - security:
           cargo_audit: false
           context:


### PR DESCRIPTION
- add rust version 1.88 to the CI test matrix for broader compatibility