### PR TITLE
fix: add conditional wasmtime check based on Rust MSRV

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- add conditional wasmtime check based on Rust MSRV(pr [#343])
+
 ## [0.1.68] - 2025-12-26
 
 ### Added
@@ -988,6 +994,8 @@ All notable changes to this project will be documented in this file.
 [#339]: https://github.com/jerus-org/ci-container/pull/339
 [#340]: https://github.com/jerus-org/ci-container/pull/340
 [#341]: https://github.com/jerus-org/ci-container/pull/341
+[#343]: https://github.com/jerus-org/ci-container/pull/343
+[Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.68...HEAD
 [0.1.68]: https://github.com/jerus-org/ci-container/compare/v0.1.67...v0.1.68
 [0.1.67]: https://github.com/jerus-org/ci-container/compare/v0.1.66...v0.1.67
 [0.1.66]: https://github.com/jerus-org/ci-container/compare/v0.1.65...v0.1.66

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,15 @@ nextsv --version
 pcu --version
 circleci-junit-fix --version
 wasm-pack --version
-wasmtime --version
+# wasmtime requires Rust 1.90+ (MSRV)
+# Compare MIN_RUST version to determine if wasmtime should be available
+WASMTIME_MSRV="1.90"
+if printf '%s\n%s\n' "$WASMTIME_MSRV" "$MIN_RUST" | sort -V | head -n1 | grep -q "^$WASMTIME_MSRV$"; then
+    # MIN_RUST >= 1.90, wasmtime must be available
+    wasmtime --version
+else
+    echo "wasmtime check skipped (requires Rust >= $WASMTIME_MSRV, container has $MIN_RUST)"
+fi
 echo "---------binaries------------------------"
 ls -l /usr/local/cargo/bin/*
 echo "---------project directory---------------"


### PR DESCRIPTION
## Summary
- Add version comparison to conditionally check wasmtime based on MIN_RUST
- wasmtime 36.0.2 requires Rust 1.90+ (MSRV)
- When MIN_RUST >= 1.90: runs `wasmtime --version` (fails if missing)
- When MIN_RUST < 1.90: skips check with explanation message

## Motivation
Container builds with MIN_RUST < 1.90 (e.g., 1.82) cannot execute wasmtime binaries compiled for newer Rust versions. This was causing test failures during container build verification.

## Test plan
- [ ] Verify 1.82 build passes (wasmtime check skipped)
- [ ] Verify 1.92 build passes (wasmtime --version succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)