### PR TITLE
feat!: migrate to circleci-toolkit v4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,27 @@
 version: 2.1
 
 parameters:
-  min-rust-version:
+  min_rust_version:
     type: string
     default: "1.87"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg
-  validation-flag:
+  validation_flag:
     type: boolean
     default: false
     description: "If true, the validation pipeline will be executed."
-  success-flag:
+  success_flag:
     type: boolean
     default: false
     description: "If true, the success pipeline will be executed."
-  release-flag:
+  release_flag:
     type: boolean
     default: false
     description: "If true, the release pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@3.1.0
+  toolkit: jerus-org/circleci-toolkit@4.0.0
   sonarcloud: sonarsource/sonarcloud@4.0.0
 
 filters: &filters
@@ -37,7 +37,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   rust-env:
     docker:
-      - image: jerusdp/ci-rust:<<pipeline.parameters.min-rust-version>>
+      - image: jerusdp/ci-rust:<<pipeline.parameters.min_rust_version>>
   base_env:
     docker:
       - image: jerusdp/ci-rust:base
@@ -94,7 +94,7 @@ commands:
 
   set-min-rust-wasi:
     parameters:
-      rust-min-version:
+      rust_min_version:
         default: "1.56"
         type: string
     steps:
@@ -103,10 +103,10 @@ commands:
           command: |
             set -exo pipefail
 
-            if [[ "1.85" = "<<parameters.rust-min-version>>" || \
-                  "1.88" = "<<parameters.rust-min-version>>" || \
-                  "1.89" = "<<parameters.rust-min-version>>" || \
-                  "1.87" = "<<parameters.rust-min-version>>" ]]; then
+            if [[ "1.85" = "<<parameters.rust_min_version>>" || \
+                  "1.88" = "<<parameters.rust_min_version>>" || \
+                  "1.89" = "<<parameters.rust_min_version>>" || \
+                  "1.87" = "<<parameters.rust_min_version>>" ]]; then
               wasi_name="wasm32-wasip1"
             else
               wasi_name="wasm32-wasi"
@@ -116,19 +116,19 @@ commands:
 
   make-test:
     parameters:
-      rust-min-version:
+      rust_min_version:
         default: "1.56"
         type: string
     steps:
       - run:
-          name: make test for minimum version <<parameters.rust-min-version>>
+          name: make test for minimum version <<parameters.rust_min_version>>
           command: |
             set -exo pipefail
 
             REPO=jerusdp/ci-rust
-            TAG=<<parameters.rust-min-version>>
+            TAG=<<parameters.rust_min_version>>
             docker build \
-                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> \
+                --build-arg MIN_RUST_VERSION=<<parameters.rust_min_version>> \
                 --build-arg MIN_RUST_WASI=$WASI_NAME \
                 -t ${REPO}/test:${TAG}-wasi \
                 --target test .
@@ -136,35 +136,35 @@ commands:
 
   publish_rust_envs:
     parameters:
-      rust-min-version:
+      rust_min_version:
         default: "1.56"
         type: string
     steps:
       - run:
-          name: Publish for minimum version <<parameters.rust-min-version>>
+          name: Publish for minimum version <<parameters.rust_min_version>>
           command: |
             set -exo pipefail
 
             REPO=jerusdp/ci-rust
-            TAG=<<parameters.rust-min-version>>
+            TAG=<<parameters.rust_min_version>>
             INPUT_RELEASE_VERSION=0.1.0
             docker build \
-                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>> \
+                --build-arg MIN_RUST_VERSION=<<parameters.rust_min_version>> \
                 --build-arg MIN_RUST_WASI=$WASI_NAME \
                 -t ${REPO}:${TAG} \
                 --target final .
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
             docker push ${REPO}:${TAG}
       - run:
-          name: Publish for minimum version <<parameters.rust-min-version>>
+          name: Publish for minimum version <<parameters.rust_min_version>>
           command: |
             set -exo pipefail
 
             REPO=jerusdp/ci-rust
-            TAG=<<parameters.rust-min-version>>
+            TAG=<<parameters.rust_min_version>>
             INPUT_RELEASE_VERSION=0.1.0
             docker build \
-                --build-arg MIN_RUST_VERSION=<<parameters.rust-min-version>>\
+                --build-arg MIN_RUST_VERSION=<<parameters.rust_min_version>>\
                 --build-arg MIN_RUST_WASI=$WASI_NAME \
                 -t ${REPO}:${TAG}-wasi \
                 --target wasi .
@@ -316,7 +316,7 @@ commands:
 jobs:
   test:
     parameters:
-      min-rust-version:
+      min_rust_version:
         type: string
     executor: ubuntu
     steps:
@@ -324,13 +324,13 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - set-min-rust-wasi:
-          rust-min-version: << parameters.min-rust-version >>
+          rust_min_version: << parameters.min_rust_version >>
       - make-test:
-          rust-min-version: << parameters.min-rust-version >>
+          rust_min_version: << parameters.min_rust_version >>
 
   publish_rustc_versions:
     parameters:
-      min-rust-version:
+      min_rust_version:
         type: string
     executor: ubuntu
     steps:
@@ -338,9 +338,9 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - set-min-rust-wasi:
-          rust-min-version: << parameters.min-rust-version >>
+          rust_min_version: << parameters.min_rust_version >>
       - publish_rust_envs:
-          rust-min-version: << parameters.min-rust-version >>
+          rust_min_version: << parameters.min_rust_version >>
 
   publish_base:
     executor: ubuntu
@@ -654,9 +654,9 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.release-flag >>
-        - not: << pipeline.parameters.validation-flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.release_flag >>
+        - not: << pipeline.parameters.validation_flag >>
 
     jobs:
       - toolkit/choose_pipeline:
@@ -671,12 +671,12 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.release-flag >>
-        - << pipeline.parameters.validation-flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.release_flag >>
+        - << pipeline.parameters.validation_flag >>
     jobs:
       - toolkit/label:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           context: pcu-app
           filters:
             branches:
@@ -688,7 +688,7 @@ workflows:
               ignore: main
           matrix: &matrix
             parameters:
-              min-rust-version:
+              min_rust_version:
                 [
                   "1.75",
                   "1.76",
@@ -718,15 +718,15 @@ workflows:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
 
   on_success:
     when:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.validation-flag >>
+        - << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.validation_flag >>
 
     jobs:
       - toolkit/end_success
@@ -736,13 +736,13 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.release-flag >>
+        - not: << pipeline.parameters.release_flag >>
     jobs:
       - toolkit/label:
           filters:
             branches:
               only: main
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           context:
             - bot-check
 
@@ -753,16 +753,16 @@ workflows:
             - and:
                 - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
                 - equal: ["release check", << pipeline.schedule.name >>]
-            - << pipeline.parameters.release-flag >>
-        - not: << pipeline.parameters.success-flag >>
-        - not: << pipeline.parameters.validation-flag >>
+            - << pipeline.parameters.release_flag >>
+        - not: << pipeline.parameters.success_flag >>
+        - not: << pipeline.parameters.validation_flag >>
     jobs:
       - make_release:
           context:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          min_rust_version: << pipeline.parameters.min_rust_version >>
           when_cargo_release: false
           when_use_workspace: false
           pcu_update_prlog: true

--- a/migrate-toolkit-v4.sh
+++ b/migrate-toolkit-v4.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Migration script for circleci-toolkit v4.0.0
+#
+# This script updates CircleCI config files to be compatible with
+# circleci-toolkit v4.0.0, which requires underscores instead of
+# hyphens in parameter names.
+#
+# Usage:
+#   ./migrate-toolkit-v4.sh [--dry-run] [--path /path/to/repo]
+#
+# Options:
+#   --dry-run    Show what would be changed without making changes
+#   --path       Path to repository (default: current directory)
+#
+# The script will:
+#   1. Update the toolkit orb version to 4.0.0
+#   2. Convert hyphenated parameter names to use underscores
+#   3. Update all references to those parameters
+#
+
+set -euo pipefail
+
+# Configuration
+DRY_RUN=false
+REPO_PATH="."
+CONFIG_FILE=".circleci/config.yml"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Parameter mappings (hyphen -> underscore)
+declare -A PARAM_MAPPINGS=(
+    ["min-rust-version"]="min_rust_version"
+    ["validation-flag"]="validation_flag"
+    ["success-flag"]="success_flag"
+    ["release-flag"]="release_flag"
+    ["rust-min-version"]="rust_min_version"
+)
+
+usage() {
+    echo "Usage: $0 [--dry-run] [--path /path/to/repo]"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run    Show what would be changed without making changes"
+    echo "  --path       Path to repository (default: current directory)"
+    echo ""
+    echo "This script migrates CircleCI config to toolkit v4.0.0"
+    exit 1
+}
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --path)
+            REPO_PATH="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate config file exists
+FULL_CONFIG_PATH="${REPO_PATH}/${CONFIG_FILE}"
+if [[ ! -f "$FULL_CONFIG_PATH" ]]; then
+    log_error "Config file not found: $FULL_CONFIG_PATH"
+    exit 1
+fi
+
+log_info "Processing: $FULL_CONFIG_PATH"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN MODE - No changes will be made"
+fi
+
+# Create backup
+if [[ "$DRY_RUN" == "false" ]]; then
+    cp "$FULL_CONFIG_PATH" "${FULL_CONFIG_PATH}.backup"
+    log_info "Backup created: ${FULL_CONFIG_PATH}.backup"
+fi
+
+# Track changes
+CHANGES_MADE=0
+
+# Function to perform sed replacement
+do_replace() {
+    local pattern="$1"
+    local replacement="$2"
+    local description="$3"
+
+    if grep -q "$pattern" "$FULL_CONFIG_PATH"; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "[DRY-RUN] Would replace: $description"
+            grep -n "$pattern" "$FULL_CONFIG_PATH" | head -5
+        else
+            sed -i "s|$pattern|$replacement|g" "$FULL_CONFIG_PATH"
+            log_info "Replaced: $description"
+        fi
+        ((CHANGES_MADE++)) || true
+    fi
+}
+
+# Step 1: Update toolkit version
+log_info "Step 1: Updating toolkit orb version..."
+do_replace \
+    "circleci-toolkit@[0-9]\+\.[0-9]\+\.[0-9]\+" \
+    "circleci-toolkit@4.0.0" \
+    "toolkit version -> 4.0.0"
+
+# Step 2: Convert parameter definitions and references
+log_info "Step 2: Converting parameter names (hyphen -> underscore)..."
+
+for old_param in "${!PARAM_MAPPINGS[@]}"; do
+    new_param="${PARAM_MAPPINGS[$old_param]}"
+
+    # Parameter definition (at start of line or after whitespace)
+    do_replace \
+        "^\([[:space:]]*\)${old_param}:" \
+        "\1${new_param}:" \
+        "parameter definition: ${old_param} -> ${new_param}"
+
+    # Parameter references in pipeline.parameters
+    do_replace \
+        "pipeline\.parameters\.${old_param}" \
+        "pipeline.parameters.${new_param}" \
+        "pipeline reference: ${old_param} -> ${new_param}"
+
+    # Parameter references with << parameters. >>
+    do_replace \
+        "<< parameters\.${old_param} >>" \
+        "<< parameters.${new_param} >>" \
+        "parameters reference: ${old_param} -> ${new_param}"
+
+    # Parameter references with <<parameters.X>> (no spaces, various contexts)
+    # This catches inline uses like TAG=<<parameters.rust-min-version>>
+    do_replace \
+        "<<parameters\.${old_param}>>" \
+        "<<parameters.${new_param}>>" \
+        "parameters reference (no space): ${old_param} -> ${new_param}"
+
+    # Parameter usage in job/command calls (indented parameter: value)
+    do_replace \
+        "^\([[:space:]]*\)${old_param}:" \
+        "\1${new_param}:" \
+        "parameter usage: ${old_param} -> ${new_param}"
+done
+
+# Step 3: Handle any remaining hyphenated parameter references that might have been missed
+# This is a catch-all for edge cases
+log_info "Step 3: Checking for any remaining hyphenated references..."
+
+for old_param in "${!PARAM_MAPPINGS[@]}"; do
+    new_param="${PARAM_MAPPINGS[$old_param]}"
+
+    # Global replacement for any remaining occurrences
+    if grep -q "${old_param}" "$FULL_CONFIG_PATH"; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            remaining=$(grep -c "${old_param}" "$FULL_CONFIG_PATH" || echo "0")
+            if [[ "$remaining" -gt 0 ]]; then
+                log_warn "[DRY-RUN] Found $remaining remaining occurrence(s) of '${old_param}':"
+                grep -n "${old_param}" "$FULL_CONFIG_PATH" | head -10
+            fi
+        fi
+    fi
+done
+
+# Step 4: Summary
+echo ""
+if [[ "$CHANGES_MADE" -gt 0 ]]; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN complete. $CHANGES_MADE change(s) would be made."
+        log_info "Run without --dry-run to apply changes."
+    else
+        log_info "Migration complete. $CHANGES_MADE change(s) made."
+        log_info "Backup saved to: ${FULL_CONFIG_PATH}.backup"
+        log_info ""
+        log_info "Next steps:"
+        log_info "  1. Review the changes: git diff ${CONFIG_FILE}"
+        log_info "  2. Validate config: circleci config validate ${CONFIG_FILE}"
+        log_info "  3. Remove backup if satisfied: rm ${FULL_CONFIG_PATH}.backup"
+    fi
+else
+    log_info "No changes needed - config appears to be already migrated."
+fi


### PR DESCRIPTION
## Summary

- Update circleci-toolkit orb from v3.1.0 to v4.0.0
- Convert all hyphenated parameter names to use underscores (breaking change required by toolkit v4.0.0)
- Add `migrate-toolkit-v4.sh` script for applying this migration to other repositories

## Breaking Change

This PR updates to circleci-toolkit v4.0.0 which requires underscores instead of hyphens in parameter names:

| Old Parameter | New Parameter |
|---------------|---------------|
| `min-rust-version` | `min_rust_version` |
| `validation-flag` | `validation_flag` |
| `success-flag` | `success_flag` |
| `release-flag` | `release_flag` |
| `rust-min-version` | `rust_min_version` |

## Migration Script

The included `migrate-toolkit-v4.sh` script can be used to apply this migration to other repositories:

```bash
# Preview changes
./migrate-toolkit-v4.sh --dry-run

# Apply changes
./migrate-toolkit-v4.sh

# Apply to another repo
./migrate-toolkit-v4.sh --path /path/to/repo
```

## Test plan

- [ ] Verify CircleCI config validates successfully
- [ ] Confirm CI pipeline runs with toolkit v4.0.0
- [ ] Test migration script on a sample repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)