### PR TITLE
feat: add cosign and gh for SLSA attestation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,22 @@ COPY --from=binaries $CARGO_HOME/bin/cargo-release \
     $CARGO_HOME/bin/pcu \
     $CARGO_HOME/bin/rsign \
     $CARGO_HOME/bin/circleci-junit-fix $CARGO_HOME/bin/
+# renovate: datasource=github-releases depName=sigstore/cosign
+ENV COSIGN_VERSION=v2.4.1
+RUN set -eux; \
+    curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+        -o /usr/local/bin/cosign \
+    && chmod +x /usr/local/bin/cosign \
+    && cosign version
+# renovate: datasource=github-releases depName=cli/cli
+ENV GH_VERSION=v2.65.0
+RUN set -eux; \
+    curl -sSfL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_linux_amd64.tar.gz" \
+        -o /tmp/gh.tar.gz \
+    && tar -xz -C /tmp -f /tmp/gh.tar.gz \
+    && install -m 755 "/tmp/gh_${GH_VERSION#v}_linux_amd64/bin/gh" /usr/local/bin/ \
+    && rm -rf "/tmp/gh_${GH_VERSION#v}_linux_amd64" /tmp/gh.tar.gz \
+    && gh --version
 ARG MIN_RUST_VERSION=1.65
 RUN rustup component add clippy rustfmt llvm-tools; \
     rustup toolchain install stable --component clippy --component rustfmt; \

--- a/Dockerfile.rolling
+++ b/Dockerfile.rolling
@@ -122,6 +122,22 @@ COPY --from=binaries $CARGO_HOME/bin/cargo-release \
     $CARGO_HOME/bin/pcu \
     $CARGO_HOME/bin/rsign \
     $CARGO_HOME/bin/circleci-junit-fix $CARGO_HOME/bin/
+# renovate: datasource=github-releases depName=sigstore/cosign
+ENV COSIGN_VERSION=v2.4.1
+RUN set -eux; \
+    curl -sSfL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+        -o /usr/local/bin/cosign \
+    && chmod +x /usr/local/bin/cosign \
+    && cosign version
+# renovate: datasource=github-releases depName=cli/cli
+ENV GH_VERSION=v2.65.0
+RUN set -eux; \
+    curl -sSfL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_linux_amd64.tar.gz" \
+        -o /tmp/gh.tar.gz \
+    && tar -xz -C /tmp -f /tmp/gh.tar.gz \
+    && install -m 755 "/tmp/gh_${GH_VERSION#v}_linux_amd64/bin/gh" /usr/local/bin/ \
+    && rm -rf "/tmp/gh_${GH_VERSION#v}_linux_amd64" /tmp/gh.tar.gz \
+    && gh --version
 
 # Install standard toolchains with all components
 RUN rustup component add clippy rustfmt llvm-tools; \

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- add cosign and gh for SLSA attestation(pr [#416])
+
 ## [0.1.87] - 2026-03-03
 
 ### Fixed
@@ -1230,6 +1236,8 @@ All notable changes to this project will be documented in this file.
 [#411]: https://github.com/jerus-org/ci-container/pull/411
 [#412]: https://github.com/jerus-org/ci-container/pull/412
 [#413]: https://github.com/jerus-org/ci-container/pull/413
+[#416]: https://github.com/jerus-org/ci-container/pull/416
+[Unreleased]: https://github.com/jerus-org/ci-container/compare/v0.1.87...HEAD
 [0.1.87]: https://github.com/jerus-org/ci-container/compare/v0.1.86...v0.1.87
 [0.1.86]: https://github.com/jerus-org/ci-container/compare/v0.1.85...v0.1.86
 [0.1.85]: https://github.com/jerus-org/ci-container/compare/v0.1.84...v0.1.85


### PR DESCRIPTION
## Summary

- Adds `cosign` (Sigstore keyless signing) to the `final` stage of both `Dockerfile` and `Dockerfile.rolling`
- Adds `gh` CLI to the `final` stage of both Dockerfiles
- Both versions are pinned with Renovate `github-releases` datasource comments for automatic updates

## Why

These tools are prerequisites for the `attest_crate` command being added to `circleci-toolkit`. That command will:
1. Download the published `.crate` from crates.io
2. Generate a SLSA v0.2 provenance JSON capturing source, build environment, and builder identity
3. Sign with `cosign` using `$CIRCLE_OIDC_TOKEN_V2` (keyless, via Sigstore Fulcio — no stored private keys)
4. Upload the `.cosign.bundle` to the GitHub release with `gh`

This replaces `compute_checksums_and_upload` (which only captures source, not build environment) with a cryptographically verifiable attestation recorded in the Sigstore Rekor public transparency log — satisfying the OpenSSF Best Practices silver badge `reproduced_build` criterion.

## Test plan

- [ ] CI builds both `final` and `wasi` Docker images successfully
- [ ] `cosign version` runs without error in the built image
- [ ] `gh --version` runs without error in the built image
- [ ] Renovate recognises the `github-releases` datasource comments and tracks both versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)