### PR TITLE
fix: bump gen-orb-mcp 0.1.10 -> 0.1.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ FROM installer AS build-domain-tools
 # renovate: datasource=crate depName=cull-gmail packageName=cull-gmail versioning=semver-coerced
 ENV CULL_GMAIL_VERSION=0.1.8
 # renovate: datasource=crate depName=gen-orb-mcp packageName=gen-orb-mcp versioning=semver-coerced
-ENV GEN_ORB_MCP_VERSION=0.1.10
+ENV GEN_ORB_MCP_VERSION=0.1.29
 RUN \
     cargo binstall --locked cull-gmail --version "${CULL_GMAIL_VERSION}" --no-confirm; \
     cargo binstall --locked gen-orb-mcp --version "${GEN_ORB_MCP_VERSION}" --no-confirm;
@@ -141,7 +141,7 @@ ENV CULL_GMAIL_VERSION=0.1.8
 # renovate: datasource=crate depName=gen-changelog packageName=gen-changelog versioning=semver-coerced
 ENV GEN_CHANGELOG_VERSION=0.1.8
 # renovate: datasource=crate depName=gen-orb-mcp packageName=gen-orb-mcp versioning=semver-coerced
-ENV GEN_ORB_MCP_VERSION=0.1.10
+ENV GEN_ORB_MCP_VERSION=0.1.29
 # renovate: datasource=crate depName=kdeets packageName=kdeets versioning=semver-coerced
 ENV KDEETS_VERSION=0.1.30
 # renovate: datasource=crate depName=nextsv packageName=nextsv versioning=semver-coerced


### PR DESCRIPTION
## Summary

- Bumps `GEN_ORB_MCP_VERSION` from `0.1.10` to `0.1.29` in both Dockerfile builder stages

## Root Cause

gen-orb-mcp v0.1.10 had a bug in `lib.rs.hbs`: `ListToolsResult`, `Tool`, `CallToolRequestParams`, and `CallToolResult` were only imported when `has_tools=true`. Orbs without migrations (`has_tools=false`) — such as gen-circleci-orb — generated code that referenced these types without importing them, causing a compile failure. Fixed in v0.1.11; bumping to v0.1.29 (latest).

## Test plan

- [ ] CI builds Docker image with new gen-orb-mcp version
- [ ] gen-circleci-orb release MCP server compilation passes after image update

🤖 Generated with [Claude Code](https://claude.com/claude-code)