### PR TITLE
fix: add clippy/rustfmt to audit image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,6 +196,12 @@ COPY --from=build-security-tools \
     $CARGO_HOME/bin/cargo-audit \
     $CARGO_HOME/bin/cargo-deny \
     $CARGO_HOME/bin/
+# SonarCloud's Rust analyzer (Clippy sensor) runs in this image — the security
+# job uses the audit_env executor. The base rust image no longer ships
+# clippy/rustfmt in its default profile, so add them explicitly for the active
+# toolchain; otherwise `cargo clippy` fails and SonarCloud reports no Clippy
+# findings ("'cargo-clippy' is not installed for the toolchain ...").
+RUN rustup component add clippy rustfmt
 USER circleci
 WORKDIR /home/circleci/project
 


### PR DESCRIPTION
Closes #499.

## Problem

The published `jerusdp/ci-rust:audit` image has **rustc 1.96.0 with no clippy/rustfmt** installed. The toolkit `security` job runs in `audit_env` (this image) and invokes SonarCloud, whose Rust analyzer (Clippy sensor) shells out to `cargo clippy`:

```
error: 'cargo-clippy' is not installed for the toolchain '1.96.0-x86_64-unknown-linux-gnu'
ERROR: Failed to check Clippy prerequisites
```

So no Clippy findings reach SonarCloud (the sensor is skipped).

## Cause

The `audit` stage relied on the base rust image's default profile for clippy/rustfmt. Recent rust images no longer include those components by default, so the audit image shipped without them. The `final` stage is unaffected because it explicitly runs `rustup component add clippy rustfmt llvm-tools`.

## Fix

Add `rustup component add clippy rustfmt` to the `audit` stage.

## Verification

Ran the exact command against the live `:audit` image (podman):

```
$ rustup component add clippy rustfmt   # succeeds
$ cargo clippy --version
clippy 0.1.96 (ac68faa20c 2026-05-25)
```