### PR TITLE
feat: add clang+cmake so the build env is robust on trixie (#526)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,16 @@ FROM docker.io/library/rust:1.96.1@sha256:1f0dbad1df66647807e6952d1db85d0b2bda76
 # renovate: datasource=crate depName=cargo-binstall packageName=cargo-binstall versioning=semver-coerced
 ENV CARGO_BINSTALL_VERSION=1.20.1
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+# Native build deps for the Rust toolchain, sized so builds stay robust as
+# the unpinned `rust` tag follows Debian stable forward (trixie today, its
+# successor after EOL): build-essential (cc/make); clang = libclang for
+# bindgen (openssl-sys on modern OpenSSL, aws-lc-sys); cmake (aws-lc-sys/
+# BoringSSL); libssl-dev + pkg-config (system OpenSSL).
 RUN apt-get update; \
     apt-get install -y --no-install-recommends \
     build-essential \
+    clang \
+    cmake \
     libssl-dev \
     pkg-config \
     && apt-get clean \
@@ -200,8 +207,12 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
     adduser \
+    build-essential \
+    clang \
+    cmake \
     git \
     libssl-dev \
+    pkg-config \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && adduser circleci
@@ -224,6 +235,8 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
     build-essential \
+    clang \
+    cmake \
     gpg \
     gpg-agent \
     libssl-dev \


### PR DESCRIPTION
Closes #526.

## What changed
Add `clang` + `cmake` (and `build-essential`/`pkg-config` where missing) to the three stages that compile Rust — `installer`, `audit`, `final`.

## Why
The base already moved to trixie on its own: the unpinned `rust:1.96.1` tag now resolves to Debian **trixie** (its digest is identical to `rust:1.96.1-trixie`), because the default `rust` tag follows Debian stable and bookworm aged out. But the build environment never gained what trixie's newer OpenSSL requires:

- `openssl-sys` on **OpenSSL 3.5+** (trixie) has no pre-generated bindings → falls to **bindgen** → needs **libclang** (`clang`).
- `aws-lc-sys` (rustls default provider) builds BoringSSL → needs **cmake**.

On bookworm's older OpenSSL these were sidestepped via pre-shipped bindings, which masked the gap. It surfaced when a consumer built the modern crypto tree on trixie — gen-circleci-orb's release container (jerus-org/gen-circleci-orb#168).

## Deliberate choice: keep the unsuffixed tag
I did **not** pin `rust:…-trixie`. Relying on the default `rust` tag means the base **auto-advances to the next Debian stable** when trixie hits EOL — rather than re-pinning `-trixie` and hitting this exact wall again later. Robustness comes from the build deps being present regardless of which Debian the default points at, not from pinning a distro.

## Validation
Diff is Dockerfile-only. `clang`/`cmake` are standard trixie packages. Full image build validation happens in this repo's CI. Worth confirming the rolling-version + wasi stages still build green.

Reference: jerus-org/gen-circleci-orb#168 made the *consuming* side self-sufficient too (`cargo install --locked` + the same builder deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)