### PR TITLE
feat: add cargo-about for license notices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN \
 
 # build-cargo-ecosystem — Cargo testing/coverage toolchain
 FROM installer AS build-cargo-ecosystem
+# renovate: datasource=crate depName=cargo-about packageName=cargo-about versioning=semver-coerced
+ENV CARGO_ABOUT_VERSION=0.9.1
 # renovate: datasource=crate depName=cargo-docs-rs packageName=cargo-docs-rs versioning=semver-coerced
 ENV CARGO_DOCS_RS_VERSION=1.0.4
 # cargo-msrv: binary only. It downloads the declared rust-version toolchain on
@@ -76,6 +78,7 @@ ENV CIRCLECI_JUNIT_FIX_VERSION=0.2.3
 # renovate: datasource=crate depName=rsign2 packageName=rsign2 versioning=semver-coerced
 ENV RSIGN2_VERSION=0.6.6
 RUN \
+    cargo binstall --locked cargo-about --version "${CARGO_ABOUT_VERSION}" --no-confirm; \
     cargo binstall --locked cargo-docs-rs --version "${CARGO_DOCS_RS_VERSION}" --no-confirm; \
     cargo binstall --locked cargo-msrv --version "${CARGO_MSRV_VERSION}" --no-confirm; \
     cargo binstall --locked cargo-expand --version "${CARGO_EXPAND_VERSION}" --no-confirm; \
@@ -140,6 +143,8 @@ ENV CARGO_BINSTALL_VERSION=1.21.0
 ENV CARGO_AUDIT_VERSION=0.22.2
 # renovate: datasource=crate depName=cargo-deny packageName=cargo-deny versioning=semver-coerced
 ENV CARGO_DENY_VERSION=0.20.2
+# renovate: datasource=crate depName=cargo-about packageName=cargo-about versioning=semver-coerced
+ENV CARGO_ABOUT_VERSION=0.9.1
 # renovate: datasource=crate depName=cargo-docs-rs packageName=cargo-docs-rs versioning=semver-coerced
 ENV CARGO_DOCS_RS_VERSION=1.0.4
 # renovate: datasource=crate depName=cargo-msrv packageName=cargo-msrv versioning=semver-coerced
@@ -250,6 +255,7 @@ COPY --from=build-security-tools \
     $CARGO_HOME/bin/cargo-deny \
     $CARGO_HOME/bin/
 COPY --from=build-cargo-ecosystem \
+    $CARGO_HOME/bin/cargo-about \
     $CARGO_HOME/bin/cargo-docs-rs \
     $CARGO_HOME/bin/cargo-msrv \
     $CARGO_HOME/bin/cargo-release \


### PR DESCRIPTION
## What & why

Adds **cargo-about** to the CI image so the release pipeline can generate and attach a `THIRD-PARTY-LICENSES` file (dependency licenses/notices) to binary releases.

## Change

cargo-about (v0.9.1, Renovate-tracked) is added to the `build-cargo-ecosystem` stage — the general cargo-plugin toolchain — and copied into the final image, following the established pattern:

- build-stage: `# renovate` comment + `ENV CARGO_ABOUT_VERSION` + `cargo binstall --locked` line
- base stage: runtime `ENV` re-declaration
- final image: `COPY --from=build-cargo-ecosystem …/cargo-about`

Placed with the general cargo tooling (not the lightweight `audit` image) so that image stays small.

## Context

First step of a small chain: this image change, then a **circleci-toolkit** step to run cargo-about at release and attach the notices, consumed by binary-releasing crates (e.g. gen-circleci-orb, which is pursuing the OpenSSF Best Practices badge). Pre-installed per the CI-container philosophy (tools baked into the image, never installed at job runtime).