### PR TITLE
docs: refresh update_prlog header comment

### DIFF
--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -5,8 +5,8 @@ version: 2.1
 # so the PRLOG update commit does not re-trigger this workflow.
 #
 # Workflow:
-#   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main
-#   label         - labels the next queued Renovate PR so it is rebased and runs
+#   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main,
+#                   then labels the next queued Renovate PR (run_label: true default)
 
 parameters:
   update_pcu:


### PR DESCRIPTION
The redundant `toolkit/label` job was already removed from this workflow, but the header comment still described a separate `label` step. Updated it to the migrated wording — labeling is built into `toolkit/update_prlog` (`run_label: true` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)